### PR TITLE
Fixing CentOS EoL

### DIFF
--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -7,6 +7,11 @@ FROM centos:8
 # build environment
 WORKDIR /root/
 
+RUN cd /etc/yum.repos.d/ &&  \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum update -y
+
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all
 

--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -9,9 +9,8 @@ WORKDIR /root/
 
 RUN cd /etc/yum.repos.d/ &&  \
     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
-    yum update -y
-
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all
 

--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -16,7 +16,7 @@ RUN cd /etc/yum.repos.d/ &&  \
 RUN dnf -y install curl wget && dnf clean all
 
 # fforego
-RUN curl -O https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz && \
+RUN curl -O https://github.com/metabase/forego/releases/download/stable/forego-stable-linux-amd64.tgz && \
     tar xf forego-stable-linux-amd64.tgz && \
     mv forego /usr/local/bin/forego
 

--- a/krb5-centos/machine/Dockerfile
+++ b/krb5-centos/machine/Dockerfile
@@ -7,6 +7,10 @@ FROM centos:8
 # build environment
 WORKDIR /root/
 
+RUN cd /etc/yum.repos.d/ &&  \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all
 


### PR DESCRIPTION
Centos went EoL so we have to point the repositories to the vault + adding a forego binary from our own repo (don't know why this was pulling from https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz rather than https://github.com/metabase/forego/releases/download/stable/forego-stable-linux-amd64.tgz, like in the upstream repo)

EDIT: THANK YOU CENTOS