### PR TITLE
make network external

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
 networks:
   example.com:
     name: example.com
+    # we need to reuse this network later on
+    external: true 
     driver: bridge
     ipam:
       config:


### PR DESCRIPTION
```
 Network mba-1060512486_mbanet2  Creating
 Network mba-1060512486_mbanet2  Created
time="2024-08-07T08:19:43Z" level=warning msg="a network with name example.com exists but was not created for project \"mba-1060512486\".\nSet `external: true` to use an existing network"
network example.com was found but has incorrect label com.docker.compose.network set to "example.com"
[up] {:mb [file .], :publish true, :prefix mba-1060512486, :network example.com, :env [], :proxy nil, :app-db postgres, :data-db :postgres-data}
time="2024-08-07T08:19:43Z" level=warning msg="/tmp/docker-compose-d-13290602022171810307.yml: `version` is obsolete"
```

from https://github.com/metabase/metabase/actions/runs/10280679666/job/28448548973?pr=46517